### PR TITLE
Fix `Player` forward declaration error

### DIFF
--- a/src/networking/clientbound_packets.h
+++ b/src/networking/clientbound_packets.h
@@ -7,6 +7,7 @@
 #include "network.h"
 #include "packet_ids.h"
 #include "core/server.h"
+#include "entities/player.h"
 #include "enums/enums.h"
 #include "utils/translation.h"
 
@@ -19,7 +20,6 @@ struct MetadataEntry;
 enum class GameEvent : uint8_t;
 class Entity;
 struct Position;
-struct Player;
 
 void sendRemoveEntityPacket(const int32_t& entityID);
 void sendPlayerInfoRemove(const Player& player);


### PR DESCRIPTION
I'm getting compilation errors on Clang on linux due to `Player` being forward-declared despite `sendTranslatedChatMessage` interfacing with Player as a fully defined type.

This appears to fix it.