### PR TITLE
Fix `RegionFile::writeHeader` chunk offset endian

### DIFF
--- a/src/world/region_file.cpp
+++ b/src/world/region_file.cpp
@@ -98,9 +98,9 @@ bool RegionFile::writeHeader() {
     for (size_t i = 0; i < 1024; ++i) {
         uint32_t offset = chunkOffsetTable[i];
         // Convert to big-endian
-        uint32_t beOffset = ((offset & 0xFF0000) >> 16) |
-                            ((offset & 0xFF00) >> 8) |
-                            (offset & 0xFF);
+        uint32_t beOffset = ((offset & 0xFF0000) >> 8) |
+							((offset & 0xFF00) << 8) |
+							((offset & 0xFF) << 16);
         fileStream.write(reinterpret_cast<const char*>(&beOffset), 4);
     }
 


### PR DESCRIPTION
This operation was not properly endian swapping, and was instead just combining the first three bytes of the integer into a singular byte via `or`.

Ideally all of these endian swap operations are centralized somewhere.

The project could also possibly be updated to utilize C++23's [std::byteswap](https://en.cppreference.com/w/cpp/numeric/byteswap) function as well to remove the need for the project to maintain it's own multi-platform byte-swap functions for each type.