### PR TITLE
Fix `Position` commutative hash collisions

### DIFF
--- a/src/entities/entity.h
+++ b/src/entities/entity.h
@@ -31,7 +31,9 @@ struct Position {
 // Hash function for Position to use in unordered_map
 struct PositionHash {
     std::size_t operator()(const Position& pos) const {
-        return std::hash<int32_t>()(pos.x) ^ std::hash<int32_t>()(pos.y) ^ std::hash<int32_t>()(pos.z);
+        return std::hash<int32_t>()(pos.x) ^
+			std::rotl(std::hash<int32_t>()(pos.y), 1) ^
+			std::rotl(std::hash<int32_t>()(pos.z), 2);
     }
 };
 


### PR DESCRIPTION
`xor` is a [commutative](https://en.wikipedia.org/wiki/Commutative_property) operation and combining these hashes will cause collisions such as `1 ^ 0 ^ 0 == 0 ^ 1 ^ 0 = 0 ^ 0 ^ 1`. Something like `rotl` to rotate the bits of the hash before combining will allow the order of the operations to matter when calculating hashes.

Maybe using a library such as [glm](https://github.com/g-truc/glm) for vector-types could be useful. It provides library-code for things like [hashing](https://github.com/g-truc/glm/blob/33b4a621a697a305bc3a7610d290677b96beb181/glm/gtx/hash.hpp#L6) and other arithmetic.