### PR TITLE
Add thread names

### DIFF
--- a/src/core/server.cpp
+++ b/src/core/server.cpp
@@ -232,6 +232,7 @@ void tickingSystem() {
 void startMiningScheduler() {
     miningRunning = true;
     miningThread = std::thread(miningScheduler, std::ref(globalPlayers), std::ref(miningRunning));
+	set_thread_name(miningThread, "miningScheduler");
 }
 
 void stopMiningScheduler() {
@@ -351,11 +352,13 @@ void runServer() {
             handleConsoleCommand(input);
         }
     });
+	set_thread_name(consoleThread, "ConsoleThread");
 
     // Detach the thread to allow it to run independently
     consoleThread.detach();
 
     std::thread tickThread(tickingSystem);
+	set_thread_name(tickThread, "TickThread");
     tickThread.detach();
 
     while (true) {

--- a/src/server/query_server.cpp
+++ b/src/server/query_server.cpp
@@ -44,6 +44,7 @@ void QueryServer::start() {
 
     running.store(true);
     listenerThread = std::thread(&QueryServer::listenLoop, this);
+	set_thread_name(listenerThread, "QueryServer");
     logMessage("[QueryServer] Query Protocol server started on UDP port " + std::to_string(port) + ".", LOG_INFO);
 }
 

--- a/src/server/rcon_server.cpp
+++ b/src/server/rcon_server.cpp
@@ -5,6 +5,7 @@
 #include "utils/le32toh.h"
 #include "core/utils.h"
 #include "utils/translation.h"
+#include "utils/thread_pool.h"
 
 
 RCONServer::RCONServer(int port, const std::string& password)
@@ -17,6 +18,7 @@ RCONServer::~RCONServer() {
 bool RCONServer::start() {
     running = true;
     listenThread = std::thread(&RCONServer::listenLoop, this);
+	set_thread_name(listenThread, "RconServer");
     logMessage("RCON server started on port " + std::to_string(port), LOG_INFO);
     return true;
 }

--- a/src/utils/thread_pool.h
+++ b/src/utils/thread_pool.h
@@ -61,4 +61,6 @@ auto thread_pool::enqueue(F&& f, Args&&... args)
     return res;
 }
 
+void set_thread_name(std::thread& thread, const char* threadName);
+
 #endif //THREADPOOL_H


### PR DESCRIPTION
Adds some thread names to help with debugging and diagnosing performance issues.

[The maximum amount of characters for a thread name for a lot of platforms is 16 characters so some of the names are somewhat shortened](https://man7.org/linux/man-pages/man3/pthread_setname_np.3.html#:~:text=The%20thread%20name%20is%20a,null%20byte%20('%5C0').). Windows code is untested.

![image](https://github.com/user-attachments/assets/015c0da2-1b7f-4892-8aeb-83ce9678f99c)
