### PR TITLE
Fix erroneous string-plus-int log messages

### DIFF
--- a/src/networking/client.cpp
+++ b/src/networking/client.cpp
@@ -690,7 +690,7 @@ void handlePlayerActions(ClientConnection& client, const std::vector<uint8_t> & 
             break;
         default:
             // Unknown action
-            logMessage("Received unknown player action: " + static_cast<int>(action), LOG_WARNING);
+            logMessage("Received unknown player action: " + std::to_string(static_cast<int>(action)), LOG_WARNING);
             break;
     }
 }
@@ -2017,7 +2017,7 @@ void handleLoginRequest(ClientConnection& client, RegistryManager& registryManag
     size_t ackIndex = 0;
     int32_t ackPacketID = parseVarInt(ackPacket, ackIndex);
     if (ackPacketID != LOGIN_ACKNOWLEDGE) {
-        logMessage("Expected Login Acknowledged packet (ID 0x03), but received packet ID: " + ackPacketID, LOG_ERROR);
+        logMessage("Expected Login Acknowledged packet (ID 0x03), but received packet ID: " + std::to_string(ackPacketID), LOG_ERROR);
         return;
     }
 
@@ -2078,7 +2078,7 @@ void handleClient(SocketType clientSocket) {
                 handleLoginRequest(client, registryManager);
             }
         } else {
-            logMessage("Invalid Handshake packet ID: " + packetID, LOG_ERROR);
+            logMessage("Invalid Handshake packet ID: " + std::to_string(packetID), LOG_ERROR);
             return;
         }
     } catch (const std::exception& e) {

--- a/src/server/query_server.cpp
+++ b/src/server/query_server.cpp
@@ -32,7 +32,7 @@ void QueryServer::start() {
     serverAddr.sin_port = htons(port);
 
     if (bind(udpSocket, reinterpret_cast<sockaddr*>(&serverAddr), sizeof(serverAddr)) == SOCKET_ERROR) {
-        logMessage("[QueryServer] Failed to bind UDP socket for Query Protocol on port " + port, LOG_ERROR);
+        logMessage("[QueryServer] Failed to bind UDP socket for Query Protocol on port " + std::to_string(port), LOG_ERROR);
 #ifdef _WIN32
         closesocket(udpSocket);
         WSACleanup();

--- a/src/world/chunk.cpp
+++ b/src/world/chunk.cpp
@@ -503,7 +503,7 @@ std::vector<uint8_t> serializeChunkSections(const std::array<std::optional<MemCh
             size_t numberOfLongs;
             std::vector<uint32_t> unpackedBlockIndices = unpackBits(section.value().blockIndices, bitsPerEntryBlock);
             if (unpackedBlockIndices.size() != 4096) {
-                logMessage("Unpacked block indices size is not 4096: " + unpackedBlockIndices.size(), LOG_ERROR);
+                logMessage("Unpacked block indices size is not 4096: " + std::to_string(unpackedBlockIndices.size()), LOG_ERROR);
             }
             std::vector<uint8_t> encodedBlockData = encodePalettedData(unpackedBlockIndices, bitsPerEntryBlock, numberOfLongs);
 
@@ -1018,7 +1018,7 @@ std::shared_ptr<Chunk> loadChunkFromDisk(int chunkX, int chunkZ) {
             // Calculate the section index
             int sectionIndex = sectionY - MIN_Y / SECTION_HEIGHT;
             if (sectionIndex < 0 || sectionIndex >= NUM_SECTIONS) {
-                logMessage("Invalid sectionY: " + static_cast<int>(sectionY), LOG_ERROR);
+                logMessage("Invalid sectionY: " + std::to_string(static_cast<int>(sectionY)), LOG_ERROR);
                 continue;
             }
 


### PR DESCRIPTION
These log messages are `const char*` + `int` and do not do actual string-appending. The integers need a `std::to_string` to properly up-cast this operation into a string-append by an integer-string